### PR TITLE
Update signalOps.py

### DIFF
--- a/hwt/interfaces/signalOps.py
+++ b/hwt/interfaces/signalOps.py
@@ -133,7 +133,7 @@ class SignalOps(object):
 
     def __rshift__(self, other):
         ">> right shift (on fixed number of bits)"
-        return self._sig.__lshift__(other)
+        return self._sig.__rshift__(other)
 
     # hdl centric
     def _reversed(self):


### PR DESCRIPTION
It seems that **self._sig.\_\_rshift\_\_(other)** should be returned in function  **\_\_lshift\_\_**, not **self._sig.\_\_rshift\_\_(other)**, isn't it?